### PR TITLE
Allow runs without heritage connection

### DIFF
--- a/WLMStats.py
+++ b/WLMStats.py
@@ -137,7 +137,7 @@ class WLMStats(object):
         #TODO return errors
         muniStatsRaw = {}
         for k, v in self.settings['types'].iteritems():
-            if v['per_muni']:
+            if v['per_muni'] and v['table']:
                 self.hApi.getMuniStatistics(table=v['table'], muniStats=muniStatsRaw, debug=False)
         #analyse and output
         self.fMuniDump.write(ujson.dumps({
@@ -209,6 +209,8 @@ class WLMStats(object):
         table_to_type = {}
         monumentDump = []
         for k, v in self.settings['types'].iteritems():
+            if not v['table']:
+                continue
             table_to_type[v['table']] = k
             monumentDump += self.hApi.getAllEntries(table=v['table'], verbose=verbose)
         

--- a/indata/wle-se-2017.json
+++ b/indata/wle-se-2017.json
@@ -1,0 +1,22 @@
+{
+  "date": "2017-07",
+  "identifier": "wle-se-2017",
+  "cats": [
+    "Category:Images from Wiki Loves Earth 2017 in Sweden"
+  ],
+  "types": {  
+      "natur": {
+        "table": null,
+        "default_wp_cat": [
+          null
+        ],
+        "commons_cat": "Protected areas of Sweden with known IDs",
+        "commons_template": "Wiki Loves Earth Sweden",
+        "url_pattern": [
+            "http://skyddadnatur.naturvardsverket.se/sknat/?nvrid="
+        ],
+        "per_muni": true,
+        "url_promised": true
+      }
+  }
+}

--- a/indata/wlm-se-2016.json
+++ b/indata/wlm-se-2016.json
@@ -1,0 +1,66 @@
+{
+  "date": "2016-09",
+  "identifier": "wlm-se-2016",
+  "cats": [
+    "Category:Images from Wiki Loves Monuments 2016 in Sweden"
+  ],
+  "types": {  
+      "bbr": {
+        "table": "se-bbr",
+        "default_wp_cat": [
+          "Listor över byggnadsminnen i Sverige per region"
+        ],
+        "commons_cat": "Listed buildings in Sweden with known IDs",
+        "commons_template": "BBR",
+        "url_pattern": [
+            "http://kulturarvsdata.se/raa/bbr/html/",
+            "http://kulturarvsdata.se/raa/bbra/html/",
+            "http://kulturarvsdata.se/raa/bbrb/html/",
+            "http://kulturarvsdata.se/raa/bbrm/html/",
+            "http://www.bebyggelseregistret.raa.se/bbr2/anlaggning/visaHistorik.raa?page=historik&visaHistorik=true&anlaggningId="
+        ],
+        "per_muni": true,
+        "url_promised": true
+      },
+      "fmis": {
+        "table": "se-fornmin",
+        "default_wp_cat": [
+          "Listor över fornminnen i Sverige per kommun",
+          "Listor över fornminnen i Sverige per socken"
+        ],
+        "commons_cat": "Archaeological monuments in Sweden with known IDs",
+        "commons_template": "Fornminne",
+        "url_pattern": [
+            "http://kulturarvsdata.se/raa/fmi/html/"
+        ],
+        "per_muni": true,
+        "url_promised": true
+      },
+      "fartyg":{
+        "table": "se-ship",
+        "default_wp_cat": [
+          "K-märkta fartyg"
+        ],
+        "commons_cat": "Listed historical ships in Sweden with known IDs",
+        "commons_template": "K-Fartyg",
+        "url_pattern": [
+            "http://www.sjohistoriska.se/sv/Kusten-runt/Fartyg--batar/K-markning-av-fartyg/K-markta-fartyg/"
+        ],
+        "per_muni": false, 
+        "url_promised": false
+      },
+      "arbetsliv":{
+        "table": "se-arbetsl",
+        "default_wp_cat": [
+          "Listor över arbetslivsmuseer i Sverige per region"
+        ],
+        "commons_cat": "Working Life Museums in Sweden with known IDs",
+        "commons_template": "Arbetslivsmuseum",
+        "url_pattern": [
+            "http://www.arbetslivsmuseer.se/"
+        ],
+        "per_muni": true, 
+        "url_promised": false
+      }
+  }
+}


### PR DESCRIPTION
This makes it possible to do runs on non-WLM competitions
e.g. WLE. While much of the statistics will simply be skipped
some, such as user statistics, will still be outputted.

Version not bumped as json structure remains the same.